### PR TITLE
Add support for setting mgo.DialInfo 

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -1,8 +1,9 @@
 package bongo
 
 import (
-	. "github.com/smartystreets/goconvey/convey"
 	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
 )
 
 // For test usage
@@ -19,6 +20,18 @@ func getConnection() *Connection {
 	}
 
 	return conn
+}
+
+func TestFailSSLConnec(t *testing.T) {
+	Convey("should fail to connect to a database because of unsupported ssl flag", t, func() {
+		conf := &Config{
+			ConnectionString: "mongodb://localhost?ssl=true",
+			Database:         "bongotest",
+		}
+
+		_, err := Connect(conf)
+		So(err.Error(), ShouldEqual, "cannot parse given URI mongodb://localhost?ssl=true due to error: unsupported connection URL option: ssl=true")
+	})
 }
 
 func TestConnect(t *testing.T) {


### PR DESCRIPTION
This enables tapping into `mgo.DialInfo` and setting up SSL when needed

Code that I use to enable SSL
```	
config := &bongo.Config{
	ConnectionString: viper.GetString("mongodb.uri"),
	Database:         viper.GetString("mongodb.database"),
}

if viper.GetBool("mongodb.ssl") {
	if config.DialInfo, err = mgo.ParseURL(config.ConnectionString); err != nil {
		panic(fmt.Sprintf("cannot parse given URI %s due to error: %s", config.ConnectionString, err.Error()))
	}

	tlsConfig := &tls.Config{}
	config.DialInfo.DialServer = func(addr *mgo.ServerAddr) (net.Conn, error) {
		conn, err := tls.Dial("tcp", addr.String(), tlsConfig)
		return conn, err
	}

	config.DialInfo.Timeout = time.Second * 3
}

connection, err = bongo.Connect(config)
if err != nil {
	log.Fatal(err)
}
```