### PR TITLE
Updated .travis.yml to build go version `1.4.x`, `1.8.x` and `master`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,10 @@ language: go
 services:
   - mongodb
 go:
-  - 1.4.2
-  - tip
+  - 1.4.x
+  - 1.8.x
+  - master
+    # NOTE: no tip, see https://github.com/travis-ci/gimme/issues/38
 install:
   - go get .
   - go get github.com/smartystreets/goconvey


### PR DESCRIPTION
NOTE: no tip, see https://github.com/travis-ci/gimme/issues/38
